### PR TITLE
glib: Make GObject.NativeType public

### DIFF
--- a/Source/glib/Object.cs
+++ b/Source/glib/Object.cs
@@ -674,7 +674,7 @@ namespace GLib {
 			get { return NativeType.ToString (); }
 		}
 
-		internal GLib.GType NativeType {
+		public GLib.GType NativeType {
 			get { return LookupGType (); }
 		}
 


### PR DESCRIPTION
This is needed in GStreamer for the DynamicSignal part and is generaly
useful.